### PR TITLE
"Start from block" input field added in passport-scanner

### DIFF
--- a/cmd/passport-scanner/README.md
+++ b/cmd/passport-scanner/README.md
@@ -17,6 +17,8 @@ Usage of `./passport-scanner`:
 ```
   -listen string
     	listen address (default ":8080")
+  -nocache
+    	prevent browser caching (default true)    	
 ```
 
 By default, the application serves content on port `8080`, but the port can be changed by specifying the `-listen` parameter.

--- a/cmd/passport-scanner/assets/tmpl/main.template
+++ b/cmd/passport-scanner/assets/tmpl/main.template
@@ -38,6 +38,11 @@
                     <input type="text" class="form-control" placeholder="Passport factory address"
                            value="{{.PassportFactoryAddress}}" id="passListPassportFactoryAddressInp">
                 </div>
+                <div class="form-group">
+                    <label for="passListStartFromBlockInp">Start from block</label>
+                    <input type="text" class="form-control" placeholder="Start from block"
+                           value="{{.StartFromBlock}}" id="passListStartFromBlockInp">
+                </div>
                 <button class="btn btn-primary btn-block" id="getPassportListBtn">Get passport list</button>
             </form>
         </div>
@@ -59,6 +64,11 @@
                     <label for="passChangesPassportAddressInp">Passport address</label>
                     <input type="text" class="form-control" placeholder="Passport address"
                            id="passChangesPassportAddressInp">
+                </div>
+                <div class="form-group">
+                    <label for="passChangesStartFromBlockInp">Start from block</label>
+                    <input type="text" class="form-control" placeholder="Start from block"
+                           value="{{.StartFromBlock}}" id="passChangesStartFromBlockInp">
                 </div>
                 <button class="btn btn-primary btn-block" id="getPassportChangesBtn">Get passport changes</button>
             </form>

--- a/cmd/passport-scanner/main.go
+++ b/cmd/passport-scanner/main.go
@@ -7,11 +7,13 @@ import (
 	"strings"
 
 	"github.com/monetha/reputation-go-sdk/cmd"
+	"github.com/monetha/reputation-go-sdk/cmd/passport-scanner/middleware"
 	"github.com/shurcooL/httpgzip"
 )
 
 var (
-	listen = flag.String("listen", ":8080", "listen address")
+	listen  = flag.String("listen", ":8080", "listen address")
+	noCache = flag.Bool("nocache", true, "prevent browser caching")
 )
 
 func main() {
@@ -28,6 +30,10 @@ func main() {
 			IndexHTML: true,
 		},
 	)
+
+	if *noCache {
+		fileServer = middleware.NoCache(fileServer)
+	}
 
 	err := http.ListenAndServe(*listen, http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		if strings.HasSuffix(req.URL.Path, ".wasm") {

--- a/cmd/passport-scanner/middleware/nocache.go
+++ b/cmd/passport-scanner/middleware/nocache.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"net/http"
+	"time"
+)
+
+// Unix epoch time
+var epoch = time.Unix(0, 0).Format(time.RFC1123)
+
+// Taken from https://github.com/mytrile/nocache
+var noCacheHeaders = map[string]string{
+	"Expires":         epoch,
+	"Cache-Control":   "no-cache, private, max-age=0",
+	"Pragma":          "no-cache",
+	"X-Accel-Expires": "0",
+}
+
+var etagHeaders = []string{
+	"ETag",
+	"If-Modified-Since",
+	"If-Match",
+	"If-None-Match",
+	"If-Range",
+	"If-Unmodified-Since",
+}
+
+// NoCache is a simple piece of middleware that sets a number of HTTP headers to prevent
+// a router (or subrouter) from being cached by an upstream proxy and/or client.
+//
+// As per http://wiki.nginx.org/HttpProxyModule - NoCache sets:
+//      Expires: Thu, 01 Jan 1970 00:00:00 UTC
+//      Cache-Control: no-cache, private, max-age=0
+//      X-Accel-Expires: 0
+//      Pragma: no-cache (for HTTP/1.0 proxies/clients)
+func NoCache(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Delete any ETag headers that may have been set
+		for _, v := range etagHeaders {
+			if r.Header.Get(v) != "" {
+				r.Header.Del(v)
+			}
+		}
+
+		// Set our NoCache headers
+		for k, v := range noCacheHeaders {
+			w.Header().Set(k, v)
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/cmd/passport-scanner/web/app/app.go
+++ b/cmd/passport-scanner/web/app/app.go
@@ -27,12 +27,14 @@ type App struct {
 	BackendURLInput dom.Inp
 
 	PassListPassFactoryAddressInput dom.Inp
+	PassListStartFromBlockInp       dom.Inp
 	GetPassportListButton           dom.Btn
 	PassportListOutputDiv           dom.Elt
 	getPassportListRequestCloser    io.Closer
 	onGetPassportListClickCb        js.Callback
 
 	PassChangesPassAddressInput     dom.Inp
+	PassChangesStartFromBlockInp    dom.Inp
 	GetPassportChangesButton        dom.Btn
 	PassportChangesOutputDiv        dom.Elt
 	getPassportChangesRequestCloser io.Closer
@@ -55,6 +57,9 @@ func (a *App) setupOnClickGetPassportList() *App {
 
 		passportFactoryAddressStr := a.PassListPassFactoryAddressInput.Value()
 		passportFactoryAddress := common.HexToAddress(passportFactoryAddressStr)
+
+		passListStartFromBlockStr := a.PassListStartFromBlockInp.Value()
+		passListStartFromBlock, _ := strconv.ParseUint(passListStartFromBlockStr, 10, 64)
 
 		backendURL := a.BackendURLInput.Value()
 		networkType := getNetworkType(backendURL)
@@ -91,7 +96,7 @@ func (a *App) setupOnClickGetPassportList() *App {
 		a.getPassportListRequestCloser = (&passportListGetter{
 			Log:        a.Log,
 			BackendURL: backendURL,
-		}).GetPassportListAsync(passportFactoryAddress, &passportListObserver{
+		}).GetPassportListAsync(passportFactoryAddress, passListStartFromBlock, &passportListObserver{
 			OnErrorFun: func(err error) {
 				a.Log("passport filtering error", "error", err.Error())
 				resultStatusDiv.RemoveAllChildren()
@@ -129,6 +134,9 @@ func (a *App) setupOnClickGetPassportChanges() *App {
 
 		passportAddressStr := a.PassChangesPassAddressInput.Value()
 		passportAddress := common.HexToAddress(passportAddressStr)
+
+		passChangesStartFromBlockStr := a.PassChangesStartFromBlockInp.Value()
+		passChangesStartFromBlock, _ := strconv.ParseUint(passChangesStartFromBlockStr, 10, 64)
 
 		backendURL := a.BackendURLInput.Value()
 		networkType := getNetworkType(backendURL)
@@ -168,7 +176,7 @@ func (a *App) setupOnClickGetPassportChanges() *App {
 		a.getPassportChangesRequestCloser = (&passportChangesGetter{
 			Log:        a.Log,
 			BackendURL: backendURL,
-		}).GetPassportChangesAsync(passportAddress, &passportChangesObserver{
+		}).GetPassportChangesAsync(passportAddress, passChangesStartFromBlock, &passportChangesObserver{
 			OnErrorFun: func(err error) {
 				a.Log("passport changes error", "error", err.Error())
 				resultStatusDiv.RemoveAllChildren()

--- a/cmd/passport-scanner/web/app/passport_changes.go
+++ b/cmd/passport-scanner/web/app/passport_changes.go
@@ -40,7 +40,7 @@ type passportChangesGetter struct {
 	BackendURL string
 }
 
-func (f *passportChangesGetter) GetPassportChangesAsync(passportAddress common.Address, o *passportChangesObserver) io.Closer {
+func (f *passportChangesGetter) GetPassportChangesAsync(passportAddress common.Address, startFromBlock uint64, o *passportChangesObserver) io.Closer {
 	backendURL := f.BackendURL
 	lf := f.Log
 	onNext := o.OnNext
@@ -55,7 +55,10 @@ func (f *passportChangesGetter) GetPassportChangesAsync(passportAddress common.A
 		e := eth.New(client, lf)
 
 		historian := facts.NewHistorian(e)
-		filterOpts := &facts.ChangesFilterOpts{Context: ctx}
+		filterOpts := &facts.ChangesFilterOpts{
+			Context: ctx,
+			Start:   startFromBlock,
+		}
 
 		var it *facts.ChangeIterator
 		it, err = historian.FilterChanges(filterOpts, passportAddress)

--- a/cmd/passport-scanner/web/app/passport_list.go
+++ b/cmd/passport-scanner/web/app/passport_list.go
@@ -37,7 +37,7 @@ type passportListGetter struct {
 	BackendURL string
 }
 
-func (f *passportListGetter) GetPassportListAsync(passportFactoryAddress common.Address, o *passportListObserver) io.Closer {
+func (f *passportListGetter) GetPassportListAsync(passportFactoryAddress common.Address, startFromBlock uint64, o *passportListObserver) io.Closer {
 	backendURL := f.BackendURL
 	lf := f.Log
 	onNext := o.OnNext
@@ -54,6 +54,7 @@ func (f *passportListGetter) GetPassportListAsync(passportFactoryAddress common.
 		pfr := passfactory.NewReader(e)
 		filterOpts := &passfactory.PassportFilterOpts{
 			Context: ctx,
+			Start:   startFromBlock,
 		}
 
 		var it *passfactory.PassportIterator

--- a/cmd/passport-scanner/web/main.go
+++ b/cmd/passport-scanner/web/main.go
@@ -26,9 +26,11 @@ func main() {
 	if err := htmlMarkupTemplate.Execute(&sb, struct {
 		BackendURL             string
 		PassportFactoryAddress string
+		StartFromBlock         int
 	}{
 		BackendURL:             "https://ropsten.infura.io",
 		PassportFactoryAddress: "0x87b7Ec2602Da6C9e4D563d788e1e29C064A364a2",
+		StartFromBlock:         4100000,
 	}); err != nil {
 		panic(err)
 	}
@@ -49,10 +51,12 @@ func main() {
 		BackendURLInput: dom.Document.GetElementById("backendURLInp").AsInput(),
 
 		PassListPassFactoryAddressInput: dom.Document.GetElementById("passListPassportFactoryAddressInp").AsInput(),
+		PassListStartFromBlockInp:       dom.Document.GetElementById("passListStartFromBlockInp").AsInput(),
 		GetPassportListButton:           dom.Document.GetElementById("getPassportListBtn").AsButton(),
 		PassportListOutputDiv:           dom.Document.GetElementById("passportListOutput"),
 
 		PassChangesPassAddressInput: dom.Document.GetElementById("passChangesPassportAddressInp").AsInput(),
+		PassChangesStartFromBlockInp: dom.Document.GetElementById("passChangesStartFromBlockInp").AsInput(),
 		GetPassportChangesButton:    dom.Document.GetElementById("getPassportChangesBtn").AsButton(),
 		PassportChangesOutputDiv:    dom.Document.GetElementById("passportChangesOutput"),
 	}).

--- a/passfactory/passfactory.go
+++ b/passfactory/passfactory.go
@@ -109,6 +109,7 @@ func (r *Reader) FilterPassports(opts *PassportFilterOpts, passportFactoryAddres
 		return nil, fmt.Errorf("passfactory: NewPassportFactoryContract: %v", err)
 	}
 
+	(*eth.Eth)(r).Log("FilterPassportCreated", "start_block", opts.Start)
 	filterOpts := &bind.FilterOpts{
 		Start:   opts.Start,
 		End:     opts.End,


### PR DESCRIPTION
* New input field "Start from block" has been added in the passport scanner that allows filtering much faster, especially in the mainnet.
* By default passport scanner prevents browser caching. No longer need to clear the browser cache after updating the passport scanner.